### PR TITLE
Fix name of config file in docs

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -69,7 +69,7 @@ source <(get-all completion zsh)  # for zsh users
 Also see `get-all completion --help` for further instructions.
 
 ## Configuration
-The command will look for the configuration file `ketall` (no extension) in `.` or `$HOME/.kube/`, unless overridden by the `--config` option.  
+The command will look for the configuration file `ketall.yaml` in `.` or `$HOME/.kube/`, unless overridden by the `--config` option.  
 The following settings can be configured:
 ```yaml
 only-scope: cluster


### PR DESCRIPTION
I tried `~/.kube/ketall` and it didn't work, so this updates the docs to match the config path [mentioned in the `config` flag](https://github.com/stackitcloud/kubectl-get-all/blob/54e3d1601d442822ad3b1f6fbc59e515e7c8fe82/cmd/root.go#L90).