### PR TITLE
Remove unused replace from go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module github.com/stackitcloud/kubectl-get-all
 
 go 1.24.0
 
-replace github.com/imdario/mergo v1.0.1 => dario.cat/mergo v1.0.1
-
 require (
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/pkg/errors v0.9.1


### PR DESCRIPTION
This replace is not used anymore, as the dependency `github.com/imdario/mergo` is gone since #8 