### PR TITLE
Pin golangci-lint version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,8 @@ jobs:
         run: go mod tidy && git diff --no-patch --exit-code
       - name: Golangci-lint
         uses: golangci/golangci-lint-action@v9.2.0
+        with:
+          version: v2.12.2
       - name: Run unit tests
         run: go test ./...
       - name: GoReleaser Build Snapshot

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -13,6 +13,13 @@ linters:
     - unparam
   disable:
     - errcheck
+  settings:
+    goconst:
+      min-len: 2
+      min-occurrences: 5
+      ignore-string-values:
+        - 'true'
+        - 'false'
   exclusions:
     generated: lax
     presets:

--- a/internal/filter/filter_test.go
+++ b/internal/filter/filter_test.go
@@ -52,7 +52,7 @@ func TestFilterByPredicate(t *testing.T) {
 				newFakeObj("o2", now.Add(-120*time.Second)),
 			}),
 			givenMaxAge:   "119s",
-			expectedNames: []string{"o1"},
+			expectedNames: []string{"o1"}, // nolint: goconst // not relevant for a const
 		},
 		{
 			name: "two objects, both too old",


### PR DESCRIPTION
Currently the golangci-lint is always latest. Lets pin that to get a known version during action runs. 
Renovate should find that and push it automatically (will check when merged).
With that we don't get situations line where the lint fails unrelated to a PR like #84 

This PR also configures goconst and add one nolint for goconst.